### PR TITLE
test(shell-mode): NL detection routing regression tests (LAC-741)

### DIFF
--- a/packages/opencode/test/cli/tui/execution-mode.test.ts
+++ b/packages/opencode/test/cli/tui/execution-mode.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { ModeController, ExecutionMode, getModeDisplay, getModeController } from "@shell-mode"
+import { handleModeToggleKey, shouldUseShellCompletion } from "@tui-integration"
+
+// Minimal KeyEvent shape for testing — only the fields handleModeToggleKey reads
+function makeKey(overrides: { ctrl?: boolean; meta?: boolean; shift?: boolean; name?: string; sequence?: string } = {}) {
+  return {
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    name: "",
+    sequence: "",
+    number: false,
+    raw: "",
+    source: "raw" as const,
+    eventType: "keydown" as never,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() {},
+    stopPropagation() {},
+    ...overrides,
+  }
+}
+
+// ──────────────────────────────────────────────────────────
+// ModeController state machine
+// ──────────────────────────────────────────────────────────
+
+describe("ModeController", () => {
+  test("default mode is Auto", () => {
+    const ctrl = new ModeController()
+    expect(ctrl.getMode()).toBe(ExecutionMode.Auto)
+  })
+
+  test("setMode changes mode", () => {
+    const ctrl = new ModeController()
+    ctrl.setMode(ExecutionMode.Shell)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Shell)
+    ctrl.setMode(ExecutionMode.Agent)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Agent)
+    ctrl.setMode(ExecutionMode.Auto)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Auto)
+  })
+
+  test("toggleMode cycles Auto → Shell → Agent → Auto", () => {
+    const ctrl = new ModeController()
+    expect(ctrl.getMode()).toBe(ExecutionMode.Auto)
+
+    expect(ctrl.toggleMode()).toBe(ExecutionMode.Shell)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Shell)
+
+    expect(ctrl.toggleMode()).toBe(ExecutionMode.Agent)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Agent)
+
+    expect(ctrl.toggleMode()).toBe(ExecutionMode.Auto)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Auto)
+  })
+
+  test("toggleMode wraps after three presses", () => {
+    const ctrl = new ModeController()
+    ctrl.toggleMode() // Auto → Shell
+    ctrl.toggleMode() // Shell → Agent
+    ctrl.toggleMode() // Agent → Auto
+    ctrl.toggleMode() // Auto → Shell (second cycle)
+    expect(ctrl.getMode()).toBe(ExecutionMode.Shell)
+  })
+
+  test("getModeDisplay returns Shell display", () => {
+    const ctrl = new ModeController()
+    ctrl.setMode(ExecutionMode.Shell)
+    const display = ctrl.getModeDisplay()
+    expect(display.name).toBe("Shell")
+    expect(display.icon).toBe(">")
+    expect(display.color).toBe("success")
+  })
+
+  test("getModeDisplay returns Agent display", () => {
+    const ctrl = new ModeController()
+    ctrl.setMode(ExecutionMode.Agent)
+    const display = ctrl.getModeDisplay()
+    expect(display.name).toBe("Agent")
+    expect(display.icon).toBe("◆")
+    expect(display.color).toBe("accent")
+  })
+
+  test("getModeDisplay returns Auto display", () => {
+    const ctrl = new ModeController()
+    ctrl.setMode(ExecutionMode.Auto)
+    const display = ctrl.getModeDisplay()
+    expect(display.name.trim()).toBe("Auto")
+    expect(display.icon).toBe("∞")
+    expect(display.color).toBe("diffAdded")
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// getModeDisplay (standalone function) — drives footer label and border color
+// ──────────────────────────────────────────────────────────
+
+describe("getModeDisplay", () => {
+  test("Shell mode has success color", () => {
+    const d = getModeDisplay(ExecutionMode.Shell)
+    expect(d.color).toBe("success")
+    expect(d.name).toBe("Shell")
+  })
+
+  test("Agent mode has accent color", () => {
+    const d = getModeDisplay(ExecutionMode.Agent)
+    expect(d.color).toBe("accent")
+    expect(d.name).toBe("Agent")
+  })
+
+  test("Auto mode has diffAdded color", () => {
+    const d = getModeDisplay(ExecutionMode.Auto)
+    expect(d.color).toBe("diffAdded")
+    expect(d.name.trim()).toBe("Auto")
+  })
+
+  test("each mode has a non-empty icon", () => {
+    for (const mode of Object.values(ExecutionMode)) {
+      expect(getModeDisplay(mode).icon.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("all three modes produce distinct colors", () => {
+    const colors = Object.values(ExecutionMode).map((m) => getModeDisplay(m).color)
+    expect(new Set(colors).size).toBe(3)
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// handleModeToggleKey — Ctrl+Space detection
+// ──────────────────────────────────────────────────────────
+
+describe("handleModeToggleKey", () => {
+  beforeEach(() => {
+    // Reset singleton to known state between tests
+    getModeController().setMode(ExecutionMode.Auto)
+  })
+
+  test("ctrl+space (name=space) triggers toggle and returns true", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, name: "space" }), ctx)
+    expect(result).toBe(true)
+    expect(modes).toHaveLength(1)
+    expect(modes[0]).toBe(ExecutionMode.Shell)
+  })
+
+  test("ctrl+space (name=\" \") triggers toggle and returns true", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, name: " " }), ctx)
+    expect(result).toBe(true)
+    expect(modes).toHaveLength(1)
+  })
+
+  test("ctrl+NUL sequence triggers toggle and returns true", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, sequence: "\x00" }), ctx)
+    expect(result).toBe(true)
+    expect(modes).toHaveLength(1)
+  })
+
+  test("non-ctrl space does not trigger toggle", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: false, name: "space" }), ctx)
+    expect(result).toBe(false)
+    expect(modes).toHaveLength(0)
+  })
+
+  test("ctrl+shift+space does not trigger toggle", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, shift: true, name: "space" }), ctx)
+    expect(result).toBe(false)
+    expect(modes).toHaveLength(0)
+  })
+
+  test("ctrl+meta+space does not trigger toggle", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, meta: true, name: "space" }), ctx)
+    expect(result).toBe(false)
+    expect(modes).toHaveLength(0)
+  })
+
+  test("unrelated key returns false and does not call setMode", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, name: "a" }), ctx)
+    expect(result).toBe(false)
+    expect(modes).toHaveLength(0)
+  })
+
+  test("keybind matcher match=true triggers toggle", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const keybind = { match: (key: string) => key === "mode_toggle" ? true : undefined }
+    const result = handleModeToggleKey(makeKey(), ctx, keybind)
+    expect(result).toBe(true)
+    expect(modes).toHaveLength(1)
+  })
+
+  test("keybind matcher match=false falls through to ctrl+space", () => {
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    // keybind doesn't match mode_toggle, but ctrl+space should NOT be used as fallback when keybind is provided
+    const keybind = { match: (_key: string) => false as unknown as undefined }
+    const result = handleModeToggleKey(makeKey({ ctrl: true, name: "space" }), keybind ? ctx : ctx, keybind)
+    // When keybind is provided and doesn't match, function returns false
+    expect(result).toBe(false)
+    expect(modes).toHaveLength(0)
+  })
+
+  test("three consecutive toggles cycle through all modes", () => {
+    getModeController().setMode(ExecutionMode.Auto)
+    const modes: ExecutionMode[] = []
+    const ctx = { setMode: (m: ExecutionMode) => modes.push(m) }
+    const key = makeKey({ ctrl: true, name: "space" })
+
+    handleModeToggleKey(key, ctx) // Auto → Shell
+    handleModeToggleKey(key, ctx) // Shell → Agent
+    handleModeToggleKey(key, ctx) // Agent → Auto
+
+    expect(modes).toEqual([ExecutionMode.Shell, ExecutionMode.Agent, ExecutionMode.Auto])
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// shouldUseShellCompletion — tab completion routing
+// ──────────────────────────────────────────────────────────
+
+describe("shouldUseShellCompletion", () => {
+  test("! prefix shell mode always uses shell completion", () => {
+    for (const mode of Object.values(ExecutionMode)) {
+      expect(shouldUseShellCompletion("shell", mode)).toBe(true)
+    }
+  })
+
+  test("Shell execution mode uses shell completion in normal prompt mode", () => {
+    expect(shouldUseShellCompletion("normal", ExecutionMode.Shell)).toBe(true)
+  })
+
+  test("Auto execution mode uses shell completion in normal prompt mode", () => {
+    expect(shouldUseShellCompletion("normal", ExecutionMode.Auto)).toBe(true)
+  })
+
+  test("Agent execution mode does not use shell completion", () => {
+    expect(shouldUseShellCompletion("normal", ExecutionMode.Agent)).toBe(false)
+  })
+})

--- a/packages/opencode/test/cli/tui/execution-mode.test.ts
+++ b/packages/opencode/test/cli/tui/execution-mode.test.ts
@@ -2,8 +2,10 @@ import { describe, test, expect, beforeEach } from "bun:test"
 import { ModeController, ExecutionMode, getModeDisplay, getModeController } from "@shell-mode"
 import { handleModeToggleKey, shouldUseShellCompletion } from "@tui-integration"
 
+import type { KeyEvent } from "@opentui/core"
+
 // Minimal KeyEvent shape for testing — only the fields handleModeToggleKey reads
-function makeKey(overrides: { ctrl?: boolean; meta?: boolean; shift?: boolean; name?: string; sequence?: string } = {}) {
+function makeKey(overrides: { ctrl?: boolean; meta?: boolean; shift?: boolean; name?: string; sequence?: string } = {}): KeyEvent {
   return {
     ctrl: false,
     meta: false,
@@ -20,7 +22,7 @@ function makeKey(overrides: { ctrl?: boolean; meta?: boolean; shift?: boolean; n
     preventDefault() {},
     stopPropagation() {},
     ...overrides,
-  }
+  } as unknown as KeyEvent
 }
 
 // ──────────────────────────────────────────────────────────

--- a/packages/opencode/test/plugin/shell-mode.test.ts
+++ b/packages/opencode/test/plugin/shell-mode.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { shouldRouteToShell } from "../../plugin/shell-mode/command-check"
 import { detectNaturalLanguage } from "../../plugin/shell-mode/natural-language"
+import { determineRouting } from "../../plugin/tui-integration/hooks"
+import { getModeController, ExecutionMode } from "../../plugin/shell-mode/mode"
 
 describe("shouldRouteToShell", () => {
   test("routes real commands to shell", async () => {
@@ -173,5 +175,127 @@ describe("detectNaturalLanguage", () => {
   test("returns undefined for real command with non-matching error", () => {
     // exit code 1 but output doesn't match error patterns
     expect(detectNaturalLanguage("cat file.txt bar.txt baz.txt", "some other output", 1)).toBeUndefined()
+  })
+})
+
+// LAC-163 regression: natural language heuristics route input correctly
+describe("detectNaturalLanguage — LAC-163 regression", () => {
+  test("detects conversational queries as natural language", () => {
+    expect(
+      detectNaturalLanguage("What does this function do?", "What: command not found", 127),
+    ).toBe(true)
+
+    expect(
+      detectNaturalLanguage("Explain the auth flow", "Explain: command not found", 127),
+    ).toBe(true)
+
+    expect(
+      detectNaturalLanguage("Help me fix this bug", "Help: command not found", 127),
+    ).toBe(true)
+
+    expect(
+      detectNaturalLanguage(
+        "How do I run the tests",
+        "How: command not found",
+        127,
+      ),
+    ).toBe(true)
+
+    expect(
+      detectNaturalLanguage(
+        "Can you refactor this module",
+        "Can: command not found",
+        127,
+      ),
+    ).toBe(true)
+
+    expect(
+      detectNaturalLanguage(
+        "Why is the build failing",
+        "Why: command not found",
+        127,
+      ),
+    ).toBe(true)
+  })
+
+  test("does not flag real shell commands that fail with legitimate errors", () => {
+    expect(
+      detectNaturalLanguage("ls -la /nonexistent", "ls: /nonexistent: No such file or directory", 1),
+    ).toBeUndefined()
+
+    expect(
+      detectNaturalLanguage("git log --oneline", "fatal: not a git repository", 128),
+    ).toBeUndefined()
+
+    expect(
+      detectNaturalLanguage("npm install", "npm ERR! code ENOENT", 1),
+    ).toBeUndefined()
+
+    expect(
+      detectNaturalLanguage("cd /tmp", "cd: too many arguments", 1),
+    ).toBeUndefined()
+  })
+
+  test("does not flag successful commands", () => {
+    expect(detectNaturalLanguage("ls -la", "total 0\ndrwxr-xr-x  2 user  staff  64 Jan  1 00:00 .", 0)).toBeUndefined()
+    expect(detectNaturalLanguage("git log --oneline", "abc1234 initial commit", 0)).toBeUndefined()
+    expect(detectNaturalLanguage("npm install", "added 100 packages in 5s", 0)).toBeUndefined()
+  })
+})
+
+describe("shouldRouteToShell — LAC-163 regression", () => {
+  test("routes shell commands to shell in auto mode", async () => {
+    expect(await shouldRouteToShell("ls -la")).toBe(true)
+    expect(await shouldRouteToShell("git log --oneline")).toBe(true)
+    expect(await shouldRouteToShell("cd /tmp")).toBe(true)
+    expect(await shouldRouteToShell("npm install")).toBe(true)
+    expect(await shouldRouteToShell("cat README.md")).toBe(true)
+    expect(await shouldRouteToShell("mkdir -p src/test")).toBe(true)
+    expect(await shouldRouteToShell("grep -r TODO .")).toBe(true)
+  })
+
+  test("routes natural language to agent in auto mode", async () => {
+    expect(await shouldRouteToShell("What does this function do?")).toBe(false)
+    expect(await shouldRouteToShell("Explain the auth flow")).toBe(false)
+    expect(await shouldRouteToShell("Help me fix this bug")).toBe(false)
+    expect(await shouldRouteToShell("How do I run the tests")).toBe(false)
+    expect(await shouldRouteToShell("Can you refactor this module")).toBe(false)
+    expect(await shouldRouteToShell("Why is the build failing")).toBe(false)
+  })
+})
+
+describe("determineRouting — LAC-163 regression", () => {
+  test("shell mode always returns shell", async () => {
+    const ctrl = getModeController()
+    ctrl.setMode(ExecutionMode.Shell)
+    expect(await determineRouting("What does this function do?")).toBe("shell")
+    expect(await determineRouting("ls -la")).toBe("shell")
+  })
+
+  test("agent mode always returns agent", async () => {
+    const ctrl = getModeController()
+    ctrl.setMode(ExecutionMode.Agent)
+    expect(await determineRouting("ls -la")).toBe("agent")
+    expect(await determineRouting("git status")).toBe("agent")
+  })
+
+  test("auto mode routes shell commands to shell", async () => {
+    const ctrl = getModeController()
+    ctrl.setMode(ExecutionMode.Auto)
+    expect(await determineRouting("ls -la")).toBe("shell")
+    expect(await determineRouting("git log --oneline")).toBe("shell")
+    expect(await determineRouting("cd /tmp")).toBe("shell")
+    expect(await determineRouting("npm install")).toBe("shell")
+  })
+
+  test("auto mode routes natural language to agent", async () => {
+    const ctrl = getModeController()
+    ctrl.setMode(ExecutionMode.Auto)
+    expect(await determineRouting("What does this function do?")).toBe("agent")
+    expect(await determineRouting("Explain the auth flow")).toBe("agent")
+    expect(await determineRouting("Help me fix this bug")).toBe("agent")
+    expect(await determineRouting("How do I run the tests")).toBe("agent")
+    expect(await determineRouting("Can you refactor this module")).toBe("agent")
+    expect(await determineRouting("Why is the build failing")).toBe("agent")
   })
 })


### PR DESCRIPTION
## Summary

- Add LAC-163 regression tests for `detectNaturalLanguage`, `shouldRouteToShell`, and `determineRouting`
- Cover conversational queries ("What does this function do?", "Explain the auth flow", etc.) and shell commands ("ls -la", "git log --oneline", "cd /tmp", "npm install")
- Test `determineRouting` integration across Shell, Agent, and Auto execution modes

Depends on #26124 (LAC-740)

## Test plan

- [x] All 32 tests pass (94 assertions)
- [x] Typecheck passes (all 13 packages cached)