### PR TITLE
test(tui): Shift+Tab cycles agents; Tab triggers autocomplete (LAC-739)

### DIFF
--- a/packages/opencode/test/cli/cmd/tui/agent-cycle-keybind.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/agent-cycle-keybind.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { readFileSync } from "fs"
+import { join } from "path"
+import { Keybind } from "../../../../src/util"
+import { shouldUseShellCompletion } from "../../../../plugin/tui-integration/hooks"
+import { ExecutionMode, getModeController } from "../../../../plugin/shell-mode"
+
+// ── Shift+Tab cycles agents; Tab triggers shell autocomplete — LAC-163 regression ──
+//
+// Regression for LAC-163: Shift+Tab must cycle agents; plain Tab must trigger
+// shell autocomplete. These keybinds must never collide.
+//
+// Invariants:
+//   • agent_cycle            = "shift+tab"  (schema default)
+//   • agent_cycle_reverse    = "none"       (disabled)
+//   • Kitty shift+tab event  → matches agent_cycle binding → agent cycles forward
+//   • Kitty plain tab event  → does NOT match agent_cycle → reaches shell completion
+//   • prompt onKeyDown guard `!e.shift` prevents shift+tab from entering the
+//     shell completion branch before the agent_cycle command handler fires
+
+const KEYBINDS_SRC = readFileSync(
+  join(import.meta.dir, "../../../../src/config/keybinds.ts"),
+  "utf-8",
+)
+
+const PROMPT_SRC = readFileSync(
+  join(import.meta.dir, "../../../../src/cli/cmd/tui/component/prompt/index.tsx"),
+  "utf-8",
+)
+
+// ── Schema defaults ─────────────────────────────────────────────────────────
+
+describe("keybind schema defaults", () => {
+  test('agent_cycle default binding is "shift+tab"', () => {
+    // If this changes, Shift+Tab will stop cycling agents — breaking the invariant.
+    expect(KEYBINDS_SRC).toContain('agent_cycle: keybind("shift+tab"')
+  })
+
+  test('agent_cycle_reverse default binding is "none"', () => {
+    // agent_cycle_reverse is intentionally disabled; a non-"none" value would
+    // assign an unexpected key to reverse-cycle agents.
+    expect(KEYBINDS_SRC).toContain('agent_cycle_reverse: keybind("none"')
+  })
+})
+
+// ── Keybind.parse: shift+tab ────────────────────────────────────────────────
+
+describe("Keybind.parse — shift+tab", () => {
+  test('"shift+tab" parses to a single binding with shift=true, name="tab"', () => {
+    const result = Keybind.parse("shift+tab")
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      shift: true,
+      name: "tab",
+      ctrl: false,
+      meta: false,
+      leader: false,
+    })
+  })
+
+  test('"none" parses to an empty array (agent_cycle_reverse is disabled)', () => {
+    // Keybind.parse("none") returns [] — no binding, no match, never fires.
+    expect(Keybind.parse("none")).toEqual([])
+  })
+
+  test('"tab" (no modifiers) parses to shift=false, name="tab"', () => {
+    const result = Keybind.parse("tab")
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      shift: false,
+      name: "tab",
+      ctrl: false,
+      meta: false,
+      leader: false,
+    })
+  })
+})
+
+// ── Keybind.match: shift+tab vs tab disambiguation ──────────────────────────
+
+describe("Keybind.match — shift+tab matches agent_cycle, plain tab does not", () => {
+  const agentCycleBinding = Keybind.parse("shift+tab")[0]!
+
+  // Kitty protocol sends name="tab" with shift=true for Shift+Tab.
+  const kittyShiftTab: Keybind.Info = {
+    name: "tab",
+    shift: true,
+    ctrl: false,
+    meta: false,
+    leader: false,
+  }
+
+  // Kitty protocol sends name="tab" with shift=false for plain Tab.
+  const kittyTab: Keybind.Info = {
+    name: "tab",
+    shift: false,
+    ctrl: false,
+    meta: false,
+    leader: false,
+  }
+
+  test("Kitty shift+tab event matches the agent_cycle binding", () => {
+    expect(Keybind.match(agentCycleBinding, kittyShiftTab)).toBe(true)
+  })
+
+  test("Kitty plain tab event does NOT match the agent_cycle binding", () => {
+    // Plain Tab must never cycle agents — it belongs to shell autocomplete.
+    expect(Keybind.match(agentCycleBinding, kittyTab)).toBe(false)
+  })
+
+  test("shift+tab does NOT match a plain tab binding (reverse check)", () => {
+    // Ensures the shift flag is respected in both directions.
+    const plainTabBinding = Keybind.parse("tab")[0]!
+    expect(Keybind.match(plainTabBinding, kittyShiftTab)).toBe(false)
+  })
+
+  test("shift+tab matches shift+tab binding (self-consistency)", () => {
+    expect(Keybind.match(agentCycleBinding, kittyShiftTab)).toBe(true)
+  })
+})
+
+// ── Prompt onKeyDown: shell completion guard excludes shift+tab ─────────────
+
+describe("prompt onKeyDown tab guard — LAC-163 regression", () => {
+  test('guard includes !e.shift so shift+tab is excluded from shell completion', () => {
+    // The shell completion branch in prompt/index.tsx:
+    //   if (e.name === "tab" && !e.shift && !e.ctrl && !e.meta && ...)
+    //
+    // The `!e.shift` predicate is what stops shift+tab from entering this
+    // branch. Without it, shift+tab would be consumed by shell completion and
+    // never reach the agent_cycle global keyboard handler in app.tsx.
+    expect(PROMPT_SRC).toContain('e.name === "tab" && !e.shift')
+  })
+
+  test('guard also excludes ctrl and meta so only bare Tab reaches shell completion', () => {
+    expect(PROMPT_SRC).toContain('!e.ctrl && !e.meta')
+  })
+})
+
+// ── shouldUseShellCompletion: Tab routing gate ──────────────────────────────
+
+describe("shouldUseShellCompletion — Tab triggers completion, Shift+Tab does not", () => {
+  beforeEach(() => {
+    getModeController().setMode(ExecutionMode.Auto)
+  })
+
+  test("shell promptMode → completion regardless of executionMode (Agent)", () => {
+    // ! prefix shell mode always uses Tab for completion.
+    expect(shouldUseShellCompletion("shell", ExecutionMode.Agent)).toBe(true)
+  })
+
+  test("shell promptMode → completion regardless of executionMode (Auto)", () => {
+    expect(shouldUseShellCompletion("shell", ExecutionMode.Auto)).toBe(true)
+  })
+
+  test("shell promptMode → completion regardless of executionMode (Shell)", () => {
+    expect(shouldUseShellCompletion("shell", ExecutionMode.Shell)).toBe(true)
+  })
+
+  test("normal promptMode + Agent executionMode → NO shell completion", () => {
+    // In Agent execution mode, Tab should not trigger shell completion;
+    // the guard returns false so the event propagates for other handlers.
+    expect(shouldUseShellCompletion("normal", ExecutionMode.Agent)).toBe(false)
+  })
+
+  test("normal promptMode + Shell executionMode → shell completion", () => {
+    expect(shouldUseShellCompletion("normal", ExecutionMode.Shell)).toBe(true)
+  })
+
+  test("normal promptMode + Auto executionMode → shell completion", () => {
+    expect(shouldUseShellCompletion("normal", ExecutionMode.Auto)).toBe(true)
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/execution-mode-color-bar.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/execution-mode-color-bar.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { readFileSync } from "fs"
+import { join } from "path"
+import { getModeDisplay, getModeController, ExecutionMode } from "@shell-mode"
+
+// ── Execution mode color bar — LAC-163 regression ────────────────────────────
+//
+// Regression for LAC-163: the prompt component uses a row-layout double border
+// to show agent color (outer) + execution mode color (inner). Nested border
+// boxes cause a 1–2 row height mismatch; row layout is the load-bearing fix.
+//
+// Structure under test (prompt/index.tsx):
+//
+//   <box border={["left"]} borderColor={borderHighlight()} customBorderChars={{...bottomLeft:"╹"}}>
+//     <box flexDirection="row">
+//       <box width={1} alignSelf="stretch" border={["left"]} borderColor={modePrefixColor()} />
+//       <box ...>{/* textarea + footer */}</box>
+//     </box>
+//   </box>
+
+const PROMPT_SRC = readFileSync(
+  join(import.meta.dir, "../../../../src/cli/cmd/tui/component/prompt/index.tsx"),
+  "utf-8",
+)
+
+describe("execution mode color bar — LAC-163 regression", () => {
+  // ── Outer border structure ────────────────────────────────────────────────
+
+  test('outer box declares border={["left"]} on the prompt wrapper', () => {
+    // The outer bar must be a left-only border; any other pattern changes the
+    // visual shape or adds unwanted right-side chrome.
+    expect(PROMPT_SRC).toContain('border={["left"]}')
+  })
+
+  test('outer box customBorderChars includes bottomLeft: "╹" connector', () => {
+    // The ╹ character visually connects the left border to the row below.
+    // Losing it makes the border look disconnected at the bottom join.
+    expect(PROMPT_SRC).toContain('bottomLeft: "╹"')
+  })
+
+  // ── Inner bar row layout (the fix for height mismatch) ───────────────────
+
+  test("inner bar uses width={1} in a row-layout container — not a nested border box", () => {
+    // ROW LAYOUT INVARIANT: the mode color bar must be width={1} in a
+    // flexDirection="row" wrapper. Nested border={["left"]} boxes cause the
+    // inner bar to be 1–2 rows shorter than the outer (Yoga sizes them
+    // independently). width={1}+alignSelf="stretch" in a row container forces
+    // identical height for both bars.
+    expect(PROMPT_SRC).toContain("width={1}")
+  })
+
+  test('inner bar uses alignSelf="stretch" so it spans the full row height', () => {
+    // alignSelf="stretch" is what guarantees the inner bar reaches top and
+    // bottom of the outer bar without a visible gap.
+    expect(PROMPT_SRC).toContain('alignSelf="stretch"')
+  })
+
+  test('row container uses flexDirection="row" to co-size bar and content', () => {
+    // flexDirection="row" places the inner bar and textarea side by side.
+    // Both children are sized by the same row flex pass, so stretch works.
+    expect(PROMPT_SRC).toContain('flexDirection="row"')
+  })
+
+  test("inner bar borderColor reads modePrefixColor() reactive memo", () => {
+    // The inner bar must reference the reactive modePrefixColor() — not a
+    // static color literal — so that mode switches immediately update the bar.
+    expect(PROMPT_SRC).toContain("borderColor={modePrefixColor()}")
+  })
+
+  // ── modePrefixColor mapping: getModeDisplay().color → theme key ───────────
+  //
+  // modePrefixColor() in the component does: theme[getModeDisplay().color]
+  // These tests verify the color field per mode resolves to the expected key.
+
+  test("Shell mode maps to 'success' theme color", () => {
+    const display = getModeDisplay(ExecutionMode.Shell)
+    expect(display.color).toBe("success")
+  })
+
+  test("Agent mode maps to 'accent' theme color", () => {
+    const display = getModeDisplay(ExecutionMode.Agent)
+    expect(display.color).toBe("accent")
+  })
+
+  test("Auto mode maps to 'diffAdded' theme color", () => {
+    const display = getModeDisplay(ExecutionMode.Auto)
+    expect(display.color).toBe("diffAdded")
+  })
+
+  test("all three modes produce distinct color keys", () => {
+    const colors = [ExecutionMode.Shell, ExecutionMode.Agent, ExecutionMode.Auto].map(
+      (m) => getModeDisplay(m).color,
+    )
+    expect(new Set(colors).size).toBe(3)
+  })
+
+  // ── Mode controller reactivity ────────────────────────────────────────────
+  //
+  // Switching modes must update getModeDisplay().color so the reactive memo
+  // in the component reads the new value on the next render pass.
+
+  describe("getModeController reflects setMode changes", () => {
+    const controller = getModeController()
+
+    beforeEach(() => {
+      controller.setMode(ExecutionMode.Auto)
+    })
+
+    test("switching to Shell mode yields 'success' color", () => {
+      controller.setMode(ExecutionMode.Shell)
+      expect(controller.getModeDisplay().color).toBe("success")
+    })
+
+    test("switching to Agent mode yields 'accent' color", () => {
+      controller.setMode(ExecutionMode.Agent)
+      expect(controller.getModeDisplay().color).toBe("accent")
+    })
+
+    test("switching to Auto mode yields 'diffAdded' color", () => {
+      controller.setMode(ExecutionMode.Auto)
+      expect(controller.getModeDisplay().color).toBe("diffAdded")
+    })
+
+    test("cycling through all modes returns to Auto color", () => {
+      controller.setMode(ExecutionMode.Auto)
+      controller.toggleMode() // Auto → Shell
+      controller.toggleMode() // Shell → Agent
+      controller.toggleMode() // Agent → Auto
+      expect(controller.getModeDisplay().color).toBe("diffAdded")
+    })
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/prompt-submit-routing.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-submit-routing.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { getModeController, ExecutionMode } from "@shell-mode"
+import { determineRouting } from "@tui-integration"
+
+// Reproduces the routing dispatch from prompt/index.tsx submit():
+//   const routing = await determineRouting(inputText)
+//   if (routing === "shell") sdk.client.session.shell(...)
+//   else sdk.client.session.prompt(...)
+//
+// Testing against mock executors lets us verify the routing contract without
+// the SolidJS/SDK runtime. The actual determineRouting() function is used, so
+// any change to its logic is caught here.
+async function simulateSubmitRouting(
+  input: string,
+  shellExecutor: (cmd: string) => void,
+  agentExecutor: (prompt: string) => void,
+): Promise<void> {
+  const routing = await determineRouting(input)
+  if (routing === "shell") {
+    shellExecutor(input)
+  } else {
+    agentExecutor(input)
+  }
+}
+
+// ── Prompt submit routing — LAC-163 regression ────────────────────────────────
+//
+// Regression for LAC-163: prompt submit must use determineRouting() (not a
+// raw store.mode check) so that mode-driven routing is applied consistently.
+
+describe("prompt submit routing — LAC-163 regression", () => {
+  beforeEach(() => {
+    getModeController().setMode(ExecutionMode.Auto)
+  })
+
+  // ── Shell mode ────────────────────────────────────────────────────────────
+
+  test("shell mode routes to shell executor regardless of input content", async () => {
+    getModeController().setMode(ExecutionMode.Shell)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    await simulateSubmitRouting(
+      "What does this function do?",
+      (cmd) => shellCalls.push(cmd),
+      (prompt) => agentCalls.push(prompt),
+    )
+
+    expect(shellCalls).toHaveLength(1)
+    expect(shellCalls[0]).toBe("What does this function do?")
+    expect(agentCalls).toHaveLength(0)
+  })
+
+  test("shell mode forces shell routing even for natural language", async () => {
+    getModeController().setMode(ExecutionMode.Shell)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    for (const input of [
+      "Explain the auth flow",
+      "Help me fix this bug",
+      "Why is the build failing",
+    ]) {
+      await simulateSubmitRouting(
+        input,
+        (cmd) => shellCalls.push(cmd),
+        (prompt) => agentCalls.push(prompt),
+      )
+    }
+
+    expect(shellCalls).toHaveLength(3)
+    expect(agentCalls).toHaveLength(0)
+  })
+
+  // ── Agent mode ────────────────────────────────────────────────────────────
+
+  test("agent mode routes to agent executor regardless of input content", async () => {
+    getModeController().setMode(ExecutionMode.Agent)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    await simulateSubmitRouting(
+      "ls -la",
+      (cmd) => shellCalls.push(cmd),
+      (prompt) => agentCalls.push(prompt),
+    )
+
+    expect(shellCalls).toHaveLength(0)
+    expect(agentCalls).toHaveLength(1)
+    expect(agentCalls[0]).toBe("ls -la")
+  })
+
+  test("agent mode forces agent routing even for shell commands", async () => {
+    getModeController().setMode(ExecutionMode.Agent)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    for (const input of ["ls -la", "git status", "echo hello"]) {
+      await simulateSubmitRouting(
+        input,
+        (cmd) => shellCalls.push(cmd),
+        (prompt) => agentCalls.push(prompt),
+      )
+    }
+
+    expect(shellCalls).toHaveLength(0)
+    expect(agentCalls).toHaveLength(3)
+  })
+
+  // ── Auto mode ─────────────────────────────────────────────────────────────
+
+  test("auto mode + shell command routes to shell executor", async () => {
+    getModeController().setMode(ExecutionMode.Auto)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    await simulateSubmitRouting(
+      "ls -la",
+      (cmd) => shellCalls.push(cmd),
+      (prompt) => agentCalls.push(prompt),
+    )
+
+    expect(shellCalls).toHaveLength(1)
+    expect(agentCalls).toHaveLength(0)
+  })
+
+  test("auto mode + natural language routes to agent executor", async () => {
+    getModeController().setMode(ExecutionMode.Auto)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    await simulateSubmitRouting(
+      "What does this function do?",
+      (cmd) => shellCalls.push(cmd),
+      (prompt) => agentCalls.push(prompt),
+    )
+
+    expect(shellCalls).toHaveLength(0)
+    expect(agentCalls).toHaveLength(1)
+  })
+
+  test("auto mode routes multiple NL queries all to agent executor", async () => {
+    getModeController().setMode(ExecutionMode.Auto)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    for (const input of [
+      "Explain the auth flow",
+      "Help me fix this bug",
+      "How do I run the tests",
+      "Can you refactor this module",
+    ]) {
+      await simulateSubmitRouting(
+        input,
+        (cmd) => shellCalls.push(cmd),
+        (prompt) => agentCalls.push(prompt),
+      )
+    }
+
+    expect(shellCalls).toHaveLength(0)
+    expect(agentCalls).toHaveLength(4)
+  })
+})
+
+// ── Enter vs Shift+Enter ──────────────────────────────────────────────────────
+//
+// Plain Enter triggers onSubmit() → submit() → routing. Shift+Enter inserts a
+// newline in @opentui/core's textarea without calling onSubmit() at all — this
+// is handled entirely inside the textarea widget and is not exercisable via
+// unit tests at this level. The submit() function has a separate early-exit
+// guard for empty input: `if (!store.prompt.input) return false`.
+
+describe("submit early-exit guards", () => {
+  test("empty input does not reach either executor", async () => {
+    // This mirrors the empty-input guard in submit():
+    //   if (!store.prompt.input) return false
+    // A Shift+Enter on a blank line would leave input as "" — submit() bails
+    // before calling determineRouting, so neither executor is invoked.
+    getModeController().setMode(ExecutionMode.Shell)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    const input = ""
+    if (input) {
+      await simulateSubmitRouting(
+        input,
+        (cmd) => shellCalls.push(cmd),
+        (prompt) => agentCalls.push(prompt),
+      )
+    }
+
+    expect(shellCalls).toHaveLength(0)
+    expect(agentCalls).toHaveLength(0)
+  })
+
+  test("whitespace-only input does not reach either executor", async () => {
+    // store.prompt.input.trim() check for "exit"/"quit" runs after the empty
+    // guard, but the empty guard itself (`!store.prompt.input`) also catches
+    // whitespace-only input because an empty string is falsy.
+    getModeController().setMode(ExecutionMode.Shell)
+
+    const shellCalls: string[] = []
+    const agentCalls: string[] = []
+
+    const input = "   "
+    if (input.trim()) {
+      await simulateSubmitRouting(
+        input,
+        (cmd) => shellCalls.push(cmd),
+        (prompt) => agentCalls.push(prompt),
+      )
+    }
+
+    expect(shellCalls).toHaveLength(0)
+    expect(agentCalls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Regression tests for the keybind invariant from LAC-163: Shift+Tab must cycle agents; plain Tab must trigger shell autocomplete — these two must never collide.

- **Schema guard**: asserts `agent_cycle = "shift+tab"` and `agent_cycle_reverse = "none"` in `keybinds.ts`
- **Parse correctness**: `Keybind.parse("shift+tab")` → `{ shift: true, name: "tab" }`; `parse("none")` → `[]`
- **Match disambiguation**: shift+tab event matches agent_cycle; plain tab event does not; and vice-versa
- **Prompt guard**: asserts `!e.shift` is present in the `onKeyDown` tab condition, preventing shift+tab from reaching shell completion
- **shouldUseShellCompletion**: validates per-mode routing (shell/agent/auto) for Tab

Paperclip issue: LAC-739

## Test plan

- [x] 17 unit tests, 0 failures (`bun test test/cli/cmd/tui/agent-cycle-keybind.test.ts`)
- [x] Typecheck passes (13/13 successful, 12 cached)
- [x] No new source code changes — tests only