### PR TITLE
docs: add "Why This Fork?" section to README (LAC-1469)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
+## Why This Fork?
+
+This is a maintained fork of [anomalyco/opencode](https://github.com/anomalyco/opencode). We forked to extend OpenCode with shell-native features we need for our own workflows that haven't landed upstream yet:
+
+- **Shell mode** — a first-class execution mode (`ctrl+space` or `!` prefix) that runs commands in a live shell instead of routing through the AI, with a distinct color bar in the TUI prompt
+- **Working directory tracking** — `getCwd()` / `setCwd()` persists the shell cwd across commands; a sentinel in bash output propagates `cd` changes back to the UI footer
+- **Natural language detection** — automatically routes input to AI when it reads like a question or instruction, to shell when it reads like a command — no prefix needed in `auto` mode
+- **Double left border UI** — two side bars in the TUI prompt: outer bar = agent color, inner bar = execution mode color, using a row layout that keeps both bars at equal height
+- **Tab → shell autocomplete** — Tab triggers shell completion; Shift+Tab cycles agents (upstream maps Tab to agent cycle)
+- **`EventCwdUpdated` SDK type** — exposes working directory change events through the JS SDK
+- **Independent versioning** — lash uses its own versioning scheme and is published independently of upstream releases
+
+We keep the fork in sync with upstream (`git fetch upstream && git merge upstream/dev`) and document merge conflicts in [UPSTREAM_SYNC.md](./UPSTREAM_SYNC.md).
+
 ---
 
 ### Installation


### PR DESCRIPTION
## Summary

- Adds a "Why This Fork?" section to the lash README explaining the motivation for forking and what features we maintain on top of upstream
- Follows the same pattern used in the Paperclip fork (lacymorrow/paperclip#20)
- Documents lash-specific features: shell mode, cwd tracking, natural language detection, double border UI, tab completion, SDK events, and independent versioning
- Rebased onto latest `lash` branch to resolve merge conflicts from upstream sync

## Paperclip Issue

LAC-1469

## Test Plan

- [x] README renders correctly on GitHub
- [x] Section appears before installation instructions
- [x] No conflicts with updated base branch