### PR TITLE
chore: add shipx.config.ts for release management

### DIFF
--- a/shipx.config.ts
+++ b/shipx.config.ts
@@ -1,0 +1,60 @@
+import type { ShipConfig } from "@lacymorrow/shipx"
+
+export default {
+	packageJsonPaths: [
+		"packages/opencode/package.json",
+		"package.json",
+		"packages/app/package.json",
+		"packages/core/package.json",
+		"packages/desktop/package.json",
+		"packages/enterprise/package.json",
+		"packages/function/package.json",
+		"packages/http-recorder/package.json",
+		"packages/llm/package.json",
+		"packages/plugin/package.json",
+		"packages/script/package.json",
+		"packages/sdk/js/package.json",
+		"packages/slack/package.json",
+		"packages/storybook/package.json",
+		"packages/ui/package.json",
+		"packages/web/package.json",
+		"sdks/vscode/package.json",
+	],
+	bumpFiles: [
+		{
+			path: "packages/extensions/zed/extension.toml",
+			pattern: /^version = "[^"]+"/m,
+			replacement: (v: string) => `version = "${v}"`,
+		},
+		{
+			path: "packages/extensions/zed/extension.toml",
+			pattern: /releases\/download\/v[^/]+\//g,
+			replacement: (v: string) => `releases/download/v${v}/`,
+		},
+	],
+	git: {
+		releaseBranch: "lash",
+		commitMessage: "release: {tag}",
+		commitFlags: "",
+		pushFlags: "--force-with-lease",
+	},
+	npm: {
+		cwd: "packages/opencode",
+		access: "public",
+	},
+	steps: {
+		test: false,
+		cleanup: false,
+		// ShipX doesn't support multi-package npm publish yet — lash needs
+		// wrapper (lashcode) + N binary packages (lashcode-{platform}-{arch}).
+		// Disable until ShipX supports multiple publish targets.
+		npm: false,
+		// ShipX creates GitHub releases from source tarballs. Lash needs to
+		// upload pre-built binary archives. Disable until ShipX supports
+		// custom release assets.
+		githubRelease: false,
+		// ShipX Homebrew step uses source tarball SHAs. Lash needs pre-built
+		// binary URLs with per-platform SHA256. Disable until supported.
+		homebrew: false,
+	},
+} satisfies ShipConfig


### PR DESCRIPTION
## Summary

- Adds `shipx.config.ts` to configure ShipX as the release CLI for Lash
- Configures version bumping across all 17 package.json files + Zed extension.toml
- Disables npm/GitHub release/Homebrew steps pending ShipX features (see below)

## ShipX Feature Gaps (filed)

ShipX handles version bumping and git operations. These features are needed before it can fully replace `release-lash.ts`:

- **LAC-2028**: Pre/post hooks for custom steps (build, pack, registry updates)
- **LAC-2025**: Multiple npm publish targets (wrapper + binary packages)
- **LAC-2026**: Custom GitHub release asset uploads
- **LAC-2027**: Pre-built binary Homebrew formulas
- **LAC-2029**: Monorepo version source config

## What works today

- Version detection from `packages/opencode/package.json`
- Interactive version bump (patch/minor/major/beta)
- Version bumping across all package.json files
- Zed extension.toml version + download URL bumping via `bumpFiles`
- Git commit, tag, and push

## Test plan

- [x] `bun ~/repo/shipx/src/cli.ts --dry-run --any-branch` — verified pipeline runs correctly
- [x] Typecheck passes (all cached)