### PR TITLE
fix(tui): restore working directory display in prompt footer

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1049,7 +1049,7 @@ export function Prompt(props: PromptProps) {
           const result = await handleShellTabCompletion({
             input: input.plainText,
             cursorPosition: input.cursorOffset,
-            cwd: sync.data.path.cwd || sync.data.path.directory || undefined,
+            cwd: sync.data.path.cwd || sync.data.path.directory || sync.path.directory || undefined,
           })
           if (result.applied) {
             input.setText(result.newInput)
@@ -1466,11 +1466,11 @@ export function Prompt(props: PromptProps) {
     return local.agent.color(agent.name)
   })
 
-  // Shortened working directory for display in footer
+  // Fall back to sync.path: store path.{directory,home} stay empty until shell-mode emits cwd.updated, so without it the prompt is blank until the user first `cd`s.
   const shortenedWorkingDir = createMemo(() => {
-    const dir = sync.data.path.cwd || sync.data.path.directory
+    const dir = sync.data.path.cwd || sync.data.path.directory || sync.path.directory
     if (!dir) return ""
-    const home = sync.data.path.home || process.env.HOME || process.env.USERPROFILE || ""
+    const home = sync.data.path.home || sync.path.home || process.env.HOME || process.env.USERPROFILE || ""
     if (home && dir.startsWith(home)) {
       return "~" + dir.slice(home.length)
     }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1049,7 +1049,7 @@ export function Prompt(props: PromptProps) {
           const result = await handleShellTabCompletion({
             input: input.plainText,
             cursorPosition: input.cursorOffset,
-            cwd: sync.data.path.cwd || sync.data.path.directory || sync.path.directory || undefined,
+            cwd: sync.data.path.cwd || sync.data.path.directory || sync.path?.directory || undefined,
           })
           if (result.applied) {
             input.setText(result.newInput)
@@ -1468,9 +1468,9 @@ export function Prompt(props: PromptProps) {
 
   // Fall back to sync.path: store path.{directory,home} stay empty until shell-mode emits cwd.updated, so without it the prompt is blank until the user first `cd`s.
   const shortenedWorkingDir = createMemo(() => {
-    const dir = sync.data.path.cwd || sync.data.path.directory || sync.path.directory
+    const dir = sync.data.path.cwd || sync.data.path.directory || sync.path?.directory
     if (!dir) return ""
-    const home = sync.data.path.home || sync.path.home || process.env.HOME || process.env.USERPROFILE || ""
+    const home = sync.data.path.home || sync.path?.home || process.env.HOME || process.env.USERPROFILE || ""
     if (home && dir.startsWith(home)) {
       return "~" + dir.slice(home.length)
     }


### PR DESCRIPTION
## Summary

- `shortenedWorkingDir` in the prompt read `sync.data.path.{cwd,directory}` from the store, but only `cwd` is ever populated (via `cwd.updated` events emitted by the shell-mode plugin on `cd`). `path.directory` stays empty in the store, so the prompt footer was blank until the user changed directories — regression noticed after the 2026-05-25 upstream sync (PR #24).
- Fall back to `sync.path` (= `project.instance.path()`) for the project root when the store fields are empty.
- Same fallback applied to the shell tab completion `cwd` argument so completions resolve against the project root before any `cd`.

## Test plan

- [x] \`bun turbo typecheck\` — 15/15 packages pass
- [ ] Launch TUI fresh; confirm the working directory shows in the prompt footer immediately (before any \`cd\`)
- [ ] In shell mode, run \`cd ~/some/dir\`; confirm the prompt footer updates to the new path
- [ ] In shell mode, type a partial path and press Tab; confirm completion resolves relative to project root before any \`cd\` and the new cwd after