### PR TITLE
fix(test): extend timeout for ripgrep tests that download the rg binary (LAC-2693)

### DIFF
--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -10,6 +10,10 @@ import { testEffect } from "../lib/effect"
 
 const it = testEffect(LayerNode.compile(Ripgrep.node))
 
+// first Ripgrep use may download and extract the rg binary, which exceeds the
+// default 5s test timeout on Windows CI runners (PowerShell Expand-Archive)
+const RG_DOWNLOAD = { timeout: 120_000 }
+
 const withTmp = <A, E, R>(f: (directory: AbsolutePath) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(
     Effect.promise(() => tmpdir()),
@@ -26,6 +30,7 @@ describe("Ripgrep", () => {
         expect(result.map((item) => item.path)).toEqual([RelativePath.make("src/match.ts")])
       }),
     ),
+    RG_DOWNLOAD,
   )
 
   it.live("greps files with include filtering", () =>
@@ -40,5 +45,6 @@ describe("Ripgrep", () => {
         expect(result[0]?.submatches[0]?.text).toBe("needle")
       }),
     ),
+    RG_DOWNLOAD,
   )
 })

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -10,6 +10,10 @@ import { testEffect } from "./lib/effect"
 
 const it = testEffect(LayerNode.compile(Ripgrep.node))
 
+// first Ripgrep use may download and extract the rg binary, which exceeds the
+// default 5s test timeout on Windows CI runners (PowerShell Expand-Archive)
+const RG_DOWNLOAD = { timeout: 120_000 }
+
 describe("Ripgrep", () => {
   it.live("keeps ignored files out of catch-all find results", () =>
     Effect.acquireUseRelease(
@@ -29,6 +33,7 @@ describe("Ripgrep", () => {
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
+    RG_DOWNLOAD,
   )
 
   it.live("never includes git metadata", () =>
@@ -61,5 +66,6 @@ describe("Ripgrep", () => {
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
+    RG_DOWNLOAD,
   )
 })


### PR DESCRIPTION
## Summary

Fixes the last remaining `unit (windows)` failures for [LAC-2693](https://paperclip.dev/LAC/issues/LAC-2693) (sibling of LAC-2386/linux).

**Stacked on #33** (which is stacked on #28). The LAC-2386 fixture/InstanceRef fixes already cleared 108 of the original 112 windows failures — the latest `unit (windows)` run on #33 ([job 86154739532](https://github.com/lacymorrow/lash/actions/runs/29028531945)) shows only 4 failures + 2 errors remaining, all in the Ripgrep suites.

## Root cause

On Windows, the first `Ripgrep.Service` use downloads the rg release zip and extracts it via PowerShell `Expand-Archive` (`packages/core/src/ripgrep/binary.ts`). That takes longer than bun's default 5s per-test timeout, so the test SIGTERMs the extraction mid-flight (`error: Unknown: ChildProcess.exitCode (...powershell.exe ... Expand-Archive ...)`), nothing gets cached, and every ripgrep test repeats the slow path:

- `packages/core/test/ripgrep.test.ts` — 2 tests
- `packages/core/test/filesystem/search.test.ts` — 2 tests

## Fix

Give those 4 tests an explicit 120s timeout. Only the first one pays the download cost; it caches `rg.exe` in `Global.Path.bin`, so subsequent tests short-circuit and stay fast. No behavior change on machines with rg on PATH (macOS/Linux dev machines: all 4 tests ran in 481ms locally).

## Acceptance criteria (LAC-2693)

- [ ] `unit (windows)` job reaches `success` — verify on this PR's CI run
- [x] No skipped-en-masse tests — real fix, no skips

## Testing

- `bun test test/ripgrep.test.ts test/filesystem/search.test.ts` in `packages/core`: 4 pass, 0 fail (macOS)
- Windows verification via this PR's `unit (windows)` job