### PR TITLE
ci: pre-install ripgrep on Windows unit runners (LAC-2700)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,18 @@ jobs:
             turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-
             turbo-${{ runner.os }}-
 
+      - name: Install ripgrep (Windows)
+        # RipgrepBinary prefers a PATH-resolved rg.exe; without one, the first
+        # ripgrep test pays a cold download + Expand-Archive that exceeds the
+        # 5s per-test timeout on hosted runners. Version pinned to match
+        # packages/core/src/ripgrep/binary.ts.
+        if: runner.os == 'Windows'
+        run: |
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/rg.zip" https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-pc-windows-msvc.zip
+          7z e "$RUNNER_TEMP/rg.zip" -o"$RUNNER_TEMP/ripgrep" rg.exe -r -y
+          "$RUNNER_TEMP/ripgrep/rg.exe" --version
+          echo "$RUNNER_TEMP/ripgrep" >> "$GITHUB_PATH"
+
       - name: Run unit tests
         timeout-minutes: 20
         run: GITHUB_ACTIONS=false bun turbo test


### PR DESCRIPTION
## Problem

The `unit (windows)` job fails on GitHub-hosted runners: every `Ripgrep` suite test errors with `Ripgrep.Error: ripgrep execution failed` (see run [29041726352](https://github.com/lacymorrow/lash/actions/runs/29041726352)). The first ripgrep call bootstraps the binary — downloading `ripgrep-15.1.0-x86_64-pc-windows-msvc.zip` and extracting it via PowerShell `Expand-Archive` — which exceeds Bun's 5s per-test timeout on hosted runners, so the child process is killed with SIGTERM.

Pre-existing on hosted Windows runners (same failure on run [27512032937](https://github.com/lacymorrow/lash/actions/runs/27512032937)); surfaced, not caused, by the LAC-2385 runner switch — same story as the linux failures fixed in #33.

## Fix

`RipgrepBinary` (`packages/core/src/ripgrep/binary.ts`) resolves `rg.exe` from PATH before falling back to download. This adds a Windows-only workflow step that downloads the pinned 15.1.0 release once, extracts `rg.exe` with `7z` (preinstalled on hosted runners), sanity-checks it with `--version`, and prepends it to `GITHUB_PATH` — so tests never pay the cold-download cost.

Deliberately uses the same github.com release asset the app itself downloads rather than `choco install ripgrep` (chocolatey community feed is rate-limit-prone on hosted runners) and pins the version to match `binary.ts`.

## Acceptance

- `unit (windows)` reaches success on GitHub-hosted `windows-2025`.

Targets `LAC-2385/blacksmith-to-github-runners` (PR #28), same as the sibling linux fix #33.

Closes LAC-2700.