### PR TITLE
fix(test): bound CLI subprocess fan-out so unit (linux) passes on GitHub-hosted runners (LAC-2715)

### DIFF
--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -8,6 +8,14 @@ import { Effect } from "effect"
 import { reply } from "../../lib/llm-server"
 import { cliIt } from "../../lib/cli-process"
 
+// Per-test (bun) timeout. Concurrent tests share the harness spawn gate
+// (see spawnGate in test/lib/cli-process.ts), so a test's wall clock includes
+// time queued behind other tests' subprocesses — the budget must cover the
+// whole suite's serialized throughput on a loaded CI runner, not one spawn.
+// Fail-fast for a genuinely hung subprocess comes from the per-spawn 30s
+// timeout (which starts only once the spawn holds a permit), not from this.
+const testTimeout = 120_000
+
 describe("opencode run (non-interactive subprocess)", () => {
   // Happy path: prompt completes, output reaches stdout, process exits 0.
   // If this fails, all the others likely will too — debug here first.
@@ -20,7 +28,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         opencode.expectExit(result, 0)
         expect(result.stdout).toBe("hello from the test llm\n")
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -42,7 +50,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         opencode.expectExit(result, 0)
         expect(result.stdout).toBe("before tool\nafter tool\n")
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -59,7 +67,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         opencode.expectExit(plain, 0)
         expect(plain.stdout).toBe("visible\n")
       }),
-    60_000,
+    testTimeout,
   )
 
   // Regression for #27371: an unknown model used to hang the process forever
@@ -79,7 +87,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(result.exitCode).not.toBe(0)
         expect(result.durationMs).toBeLessThan(30_000)
       }),
-    60_000,
+    testTimeout,
   )
 
   // The test provider's SSE error item is interpreted by the SDK as an unknown
@@ -101,7 +109,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(result.stdout).toBe("partial response\n")
         expect(result.stderr).not.toContain("upstream provider exploded mid-stream")
       }),
-    60_000,
+    testTimeout,
   )
 
   // --format json puts one JSON object per line on stdout for each emitted
@@ -138,7 +146,7 @@ describe("opencode run (non-interactive subprocess)", () => {
             .every((line) => line.length > 0),
         ).toBe(true)
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -161,7 +169,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         })
         expect(result.stdout.split("\n").filter(Boolean)).toHaveLength(1)
       }),
-    30_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -210,7 +218,7 @@ describe("opencode run (non-interactive subprocess)", () => {
             .every((line) => line.startsWith("{")),
         ).toBe(true)
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -239,7 +247,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(events[1]?.part).toEqual(expect.objectContaining({ type: "text", text: "partial json" }))
         expect(events.at(-1)?.part).toEqual(expect.objectContaining({ type: "step-finish", reason: "unknown" }))
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -275,7 +283,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(explicitlyDenied.stdout).toContain("continued after explicit denial")
         expect(yield* Effect.promise(() => Bun.file(`${home}/explicitly-denied`).exists())).toBe(false)
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.live(
@@ -297,7 +305,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(input).toContain(sentinel)
         expect(input).not.toContain(`file://${source}`)
       }),
-    60_000,
+    testTimeout,
   )
 
   cliIt.concurrent(
@@ -311,7 +319,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(result.exitCode).not.toBe(0)
         expect(result.stderr).toContain("Cannot attach local directory without a shared filesystem")
       }),
-    30_000,
+    testTimeout,
   )
 
   cliIt.live(
@@ -327,6 +335,6 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(result.exitCode).not.toBe(0)
         expect(result.durationMs).toBeLessThan(30_000)
       }),
-    30_000,
+    testTimeout,
   )
 })

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -20,9 +20,11 @@
 import { test, type TestOptions } from "bun:test"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { AppProcess } from "@opencode-ai/core/process"
-import { Deferred, Duration, Effect, Layer, Queue, Schedule, Scope, Stream } from "effect"
+import { Deferred, Duration, Effect, Layer, Queue, Schedule, Scope, Semaphore, Stream } from "effect"
 import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { ChildProcess } from "effect/unstable/process"
+import fs from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import { TestLLMServer } from "./llm-server"
 import { testProviderConfig } from "./test-provider"
@@ -32,6 +34,22 @@ const opencodeRoot = path.resolve(import.meta.dir, "../../")
 const cliEntry = path.join(opencodeRoot, "src/index.ts")
 
 export const testModelID = "test/test-model"
+
+// Cold-starting `bun run src/index.ts` transpiles the whole dependency graph.
+// With every cliIt.concurrent test spawning subprocesses at once, unbounded
+// fan-out starves small CI runners (4 vCPU on GitHub-hosted ubuntu) until every
+// child blows its 30s timeout with empty stdout (LAC-2715). Two mitigations:
+//
+// 1. spawnGate caps concurrent short-lived spawns near the core count. The
+//    per-spawn timer starts after the permit is acquired, so queue wait is not
+//    charged against timeoutMs or durationMs.
+// 2. All children share one Bun transpiler cache. isolatedEnv points HOME and
+//    XDG_CACHE_HOME at a fresh tmpdir per test, which would otherwise leave
+//    every child's transpiler cache cold. The cache is content-addressed, so
+//    sharing it does not leak state between tests.
+const spawnGate = Semaphore.makeUnsafe(Math.max(2, Math.min(4, Math.floor(os.availableParallelism() / 2))))
+const sharedTranspilerCache = path.join(os.tmpdir(), "opencode-test-bun-transpiler-cache")
+fs.mkdirSync(sharedTranspilerCache, { recursive: true })
 
 // Wrap a Bun subprocess pipe (or any ReadableStream<Uint8Array>) as a Stream.
 // Centralizes the `evaluate` + `onError` boilerplate and tags errors with the
@@ -65,6 +83,7 @@ function isolatedEnv(home: string, configJson: string): Record<string, string> {
     XDG_DATA_HOME: path.join(home, ".local/share"),
     XDG_STATE_HOME: path.join(home, ".local/state"),
     XDG_CACHE_HOME: path.join(home, ".cache"),
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: sharedTranspilerCache,
     OPENCODE_CONFIG_CONTENT: configJson,
     OPENCODE_DISABLE_PROJECT_CONFIG: "1",
     OPENCODE_PURE: "1",
@@ -203,47 +222,57 @@ export function withCliFixture<A, E>(
     const env = isolatedEnv(home, configJson)
 
     const spawn = Effect.fn("opencode.spawn")(function* (args: string[], opts?: SpawnOpts) {
-      const start = Date.now()
-      const timeoutMs = opts?.timeoutMs ?? 30_000
-      // stdin: "ignore" so the child doesn't see a piped stdin and block
-      // on `Bun.stdin.text()` (see src/cli/cmd/run.ts — non-TTY stdin is
-      // consumed as the prompt). The old Process.run wrapper defaulted to
-      // ignore; ChildProcess.make defaults to pipe, so we set it explicitly.
-      const command = ChildProcess.make("bun", ["run", "--conditions=browser", cliEntry, ...args], {
-        cwd: home,
-        env: { ...env, ...opts?.env },
-        extendEnv: true,
-        stdin: "ignore",
-      })
-      // Pass timeout to appProc.run rather than wrapping with
-      // Effect.timeoutOrElse externally: AppProcess.run is itself scoped, so
-      // its built-in timeout triggers the acquireRelease kill finalizer
-      // inside cross-spawn-spawner *before* surfacing the AppProcessError —
-      // guaranteeing the child is dead by the time the test continues.
-      // External timeoutOrElse interrupts the run fiber but races the
-      // scope close, which can leak the child past the test boundary.
-      //
-      // Catch AppProcessError (timeout OR spawn failure) and synthesize a
-      // non-zero result so the test sees it via the usual `expectExit`
-      // path rather than as an unhandled Effect failure.
-      const result = yield* appProc.run(command, { timeout: Duration.millis(timeoutMs) }).pipe(
-        Effect.catchTag("AppProcessError", (err) =>
-          Effect.succeed({
-            command: err.command,
-            exitCode: err.exitCode ?? -1,
-            stdout: Buffer.alloc(0),
-            stderr: Buffer.from((err.stderr ?? String(err.cause ?? err.message)) + "\n"),
-            stdoutTruncated: false,
-            stderrTruncated: false,
-          } satisfies AppProcess.RunResult),
-        ),
+      return yield* spawnGate.withPermits(1)(
+        Effect.gen(function* () {
+          const start = Date.now()
+          const timeoutMs = opts?.timeoutMs ?? 30_000
+          // stdin: "ignore" so the child doesn't see a piped stdin and block
+          // on `Bun.stdin.text()` (see src/cli/cmd/run.ts — non-TTY stdin is
+          // consumed as the prompt). The old Process.run wrapper defaulted to
+          // ignore; ChildProcess.make defaults to pipe, so we set it explicitly.
+          const command = ChildProcess.make("bun", ["run", "--conditions=browser", cliEntry, ...args], {
+            cwd: home,
+            env: { ...env, ...opts?.env },
+            extendEnv: true,
+            stdin: "ignore",
+          })
+          // Pass timeout to appProc.run rather than wrapping with
+          // Effect.timeoutOrElse externally: AppProcess.run is itself scoped, so
+          // its built-in timeout triggers the acquireRelease kill finalizer
+          // inside cross-spawn-spawner *before* surfacing the AppProcessError —
+          // guaranteeing the child is dead by the time the test continues.
+          // External timeoutOrElse interrupts the run fiber but races the
+          // scope close, which can leak the child past the test boundary.
+          //
+          // Catch AppProcessError (timeout OR spawn failure) and synthesize a
+          // non-zero result so the test sees it via the usual `expectExit`
+          // path rather than as an unhandled Effect failure. AppProcess drops
+          // the child's collected stderr on timeout, so annotate the synthetic
+          // message with timing to make CI failures diagnosable.
+          const result = yield* appProc.run(command, { timeout: Duration.millis(timeoutMs) }).pipe(
+            Effect.catchTag("AppProcessError", (err) =>
+              Effect.succeed({
+                command: err.command,
+                exitCode: err.exitCode ?? -1,
+                stdout: Buffer.alloc(0),
+                stderr: Buffer.from(
+                  (err.stderr ??
+                    `${String(err.cause ?? err.message)} after ${Date.now() - start}ms (timeout ${timeoutMs}ms)`) +
+                    "\n",
+                ),
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              } satisfies AppProcess.RunResult),
+            ),
+          )
+          return {
+            exitCode: result.exitCode,
+            stdout: normalizeLines(result.stdout.toString()),
+            stderr: normalizeLines(result.stderr.toString()),
+            durationMs: Date.now() - start,
+          }
+        }),
       )
-      return {
-        exitCode: result.exitCode,
-        stdout: normalizeLines(result.stdout.toString()),
-        stderr: normalizeLines(result.stderr.toString()),
-        durationMs: Date.now() - start,
-      }
     })
 
     const runArgs = (message: string, opts?: RunOpts) => {

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -48,7 +48,17 @@ export const testModelID = "test/test-model"
 //    every child's transpiler cache cold. The cache is content-addressed, so
 //    sharing it does not leak state between tests.
 const spawnGate = Semaphore.makeUnsafe(Math.max(2, Math.min(4, Math.floor(os.availableParallelism() / 2))))
-const sharedTranspilerCache = path.join(os.tmpdir(), "opencode-test-bun-transpiler-cache")
+// Suffix the cache dir with the username: os.tmpdir() is shared, and another
+// user's 0755 cache dir would EACCES our transpiler-cache writes. userInfo()
+// can throw in containers without a passwd entry, hence the fallback chain.
+const cacheOwner = (() => {
+  try {
+    return os.userInfo().username
+  } catch {
+    return process.env["USER"] || process.env["USERNAME"] || "default"
+  }
+})()
+const sharedTranspilerCache = path.join(os.tmpdir(), `opencode-test-bun-transpiler-cache-${cacheOwner}`)
 fs.mkdirSync(sharedTranspilerCache, { recursive: true })
 
 // Wrap a Bun subprocess pipe (or any ReadableStream<Uint8Array>) as a Stream.


### PR DESCRIPTION
## Paperclip issue

[LAC-2715](https://paperclip.dev/LAC/issues/LAC-2715) — Fix unit (linux) CI failures: `opencode run (non-interactive subprocess)` suite times out at ~30s on GitHub-hosted runners.

## Root cause

The suite spawns one cold `bun run src/index.ts` subprocess per `cliIt.concurrent` test with **unbounded fan-out** (~10 at once, some tests spawn 3 sequentially). Each child re-transpiles the entire dependency graph, and the harness's per-test `HOME`/`XDG_CACHE_HOME` isolation leaves every child's Bun transpiler cache cold. On a 4-vCPU GitHub-hosted runner the simultaneous cold starts starve each other until every full-session child hits its 30s subprocess timeout with empty stdout (`exit -1`, `Error: Timed out`) — exactly the 7 failures on run [29067555482](https://github.com/lacymorrow/lash/actions/runs/29067555482). The tests that survived are the fail-fast ones (unknown model, bad attach) that exit before the heavy boot.

**Reproduced locally**: fresh install/cold caches → 8 fail; warm second run → 13 pass. Deterministic A/B under 12× CPU-hog stress: unfixed → 5 pass / 8 fail (same signature as CI), fixed → 13 pass.

## Fix (no blind timeout raises — root cause + fail-fast diagnostics)

- **`spawnGate` semaphore** in `test/lib/cli-process.ts` caps concurrent short-lived CLI spawns at `max(2, min(4, cores/2))`. The per-spawn 30s timer starts only once the permit is held, so queue wait is not charged against `timeoutMs`/`durationMs` and a genuinely hung subprocess still dies at 30s.
- **Shared Bun transpiler cache** across children via `BUN_RUNTIME_TRANSPILER_CACHE_PATH` (content-addressed, so per-test isolation is preserved). Only the first spawn pays the transpile cost; local full `test/cli/` runtime dropped 305s → 219s.
- **Better timeout diagnostics**: `AppProcess` drops collected stderr on timeout, so the synthesized stderr now includes elapsed time and the budget (`Timed out after Xms (timeout 30000ms)`) instead of a bare `Error: Timed out`.
- **Per-test bun timeouts → 120s** in `run-process.test.ts`: with gated spawns a test's wall clock includes queueing behind other tests, so the test-level budget must cover serialized suite throughput. Hang detection lives in the per-spawn timeout, not the test timeout. Duration regression assertions (`durationMs < 30_000`) are unchanged and now measure pure subprocess time.

## Acceptance criteria

- `unit (linux)` reaches `success` on GitHub-hosted runners → verified by this PR's own CI (base: `LAC-2385/blacksmith-to-github-runners`).

## Testing

- `bun test test/cli/run/run-process.test.ts` — 13 pass, cold shared cache.
- Same, under 12 concurrent CPU hogs (starved-runner simulation) — 13 pass (control without fix: 8 fail).
- `bun test test/cli/` (all 53 files using or adjacent to the fixture) — 414 pass / 0 fail.
- `bun run typecheck` (packages/opencode) — clean.