### PR TITLE
fix(test): deflake tool.shell metadata streaming test (LAC-2722)

### DIFF
--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1112,10 +1112,16 @@ describe("tool.shell abort", () => {
           const gate = path
             .join(os.tmpdir(), `shell-stream-gate-${process.pid}-${Math.random().toString(36).slice(2)}`)
             .replaceAll("\\", "/")
+          // String.fromCharCode keeps the eval'd code free of quote characters so it
+          // survives evalarg's quoting under every shell (bash, pwsh, cmd).
+          const js = (text: string) => `String.fromCharCode(${[...text].map((c) => c.charCodeAt(0)).join(",")})`
+          const code = `const f=require(${js("fs")});f.writeSync(1,${js("first\n")});while(!f.existsSync(Bun.argv[1]))Bun.sleepSync(50);f.writeSync(1,${js("second\n")})`
+          const text = `${bin} -e ${evalarg(code)} ${quote(gate)}`
           const updates: string[] = []
+          let gateWritten = false
           const result = yield* run(
             {
-              command: `echo first; until [ -f "${gate}" ]; do sleep 0.05; done; echo second`,
+              command: PS.has(sh()) ? `& ${text}` : text,
               timeout: 10_000,
             },
             {
@@ -1124,7 +1130,10 @@ describe("tool.shell abort", () => {
                 Effect.sync(() => {
                   const output = (input.metadata as { output?: string })?.output
                   if (output) updates.push(output)
-                  if (output?.includes("first")) fs.writeFileSync(gate, "")
+                  if (output?.includes("first") && !gateWritten) {
+                    gateWritten = true
+                    fs.writeFileSync(gate, "")
+                  }
                 }),
             },
           ).pipe(Effect.ensuring(Effect.sync(() => fs.rmSync(gate, { force: true }))))

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -2,6 +2,7 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { describe, expect } from "bun:test"
 import { Cause, Effect, Exit, Layer } from "effect"
 import type * as Scope from "effect/Scope"
+import fs from "fs"
 import os from "os"
 import path from "path"
 import { Config } from "@/config/config"
@@ -1100,29 +1101,39 @@ describe("tool.shell abort", () => {
     ),
   )
 
-  it.live("streams metadata updates progressively", () =>
-    runIn(
-      projectRoot,
-      Effect.gen(function* () {
-        const updates: string[] = []
-        const result = yield* run(
-          {
-            command: `echo first && sleep 0.1 && echo second`,
-          },
-          {
-            ...ctx,
-            metadata: (input) =>
-              Effect.sync(() => {
-                const output = (input.metadata as { output?: string })?.output
-                if (output) updates.push(output)
-              }),
-          },
-        )
-        expect(result.output).toContain("first")
-        expect(result.output).toContain("second")
-        expect(updates.length).toBeGreaterThan(1)
-      }),
-    ),
+  it.live(
+    "streams metadata updates progressively",
+    () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          // The second chunk is gated on the test observing the first update, so the
+          // two writes can never coalesce into a single flush under runner load.
+          const gate = path
+            .join(os.tmpdir(), `shell-stream-gate-${process.pid}-${Math.random().toString(36).slice(2)}`)
+            .replaceAll("\\", "/")
+          const updates: string[] = []
+          const result = yield* run(
+            {
+              command: `echo first; until [ -f "${gate}" ]; do sleep 0.05; done; echo second`,
+              timeout: 10_000,
+            },
+            {
+              ...ctx,
+              metadata: (input) =>
+                Effect.sync(() => {
+                  const output = (input.metadata as { output?: string })?.output
+                  if (output) updates.push(output)
+                  if (output?.includes("first")) fs.writeFileSync(gate, "")
+                }),
+            },
+          ).pipe(Effect.ensuring(Effect.sync(() => fs.rmSync(gate, { force: true }))))
+          expect(result.output).toContain("first")
+          expect(result.output).toContain("second")
+          expect(updates.length).toBeGreaterThan(1)
+        }),
+      ),
+    15_000,
   )
 })
 


### PR DESCRIPTION
## Summary

Fixes the flaky `tool.shell abort > streams metadata updates progressively` test ([LAC-2722](https://paperclip.dev/LAC/issues/LAC-2722)) seen on GitHub-hosted linux runners, e.g. run [29081382435](https://github.com/lacymorrow/lash/actions/runs/29081382435).

## Problem

The test asserted `updates.length > 1` for a command emitting two output chunks separated by `sleep 0.1`. Under full-suite load, both chunks arrived within one flush window and coalesced into a single metadata update — the assertion was racing the scheduler, not testing the streaming contract.

## Fix

Make the producer deterministic instead of raising thresholds: the fixture command now emits the second chunk only after the test observes the first metadata update, signaled via a tmpdir sentinel file written from the metadata callback. Two distinct updates are guaranteed by construction, independent of runner load.

Also adds an explicit 10s command timeout and 15s test timeout so a genuine streaming regression fails cleanly instead of hanging on the gate.

## Testing

- `bun test test/tool/shell.test.ts -t 'streams metadata updates progressively'` — 10 consecutive sequential passes
- Same test 5/5 passes under artificial 6-core busy-loop CPU load (reproducing the coalescing condition)
- Full `test/tool/shell.test.ts` — 23 pass / 0 fail (3 consecutive runs)
- `bun run typecheck` in `packages/opencode` — clean

## Acceptance criteria

- Deterministic pass on linux runners under load: the second chunk cannot be emitted until the first update is observed, so coalescing is impossible by construction. CI on this PR + one subsequent run will confirm across two consecutive CI runs.