### PR TITLE
fix(shell-mode): cd does not update footer cwd (LAC-3732)

### DIFF
--- a/packages/opencode/plugin/shell-mode/cwd.ts
+++ b/packages/opencode/plugin/shell-mode/cwd.ts
@@ -46,8 +46,13 @@ export function getCwd(fallback?: string): string {
 /**
  * Set the current working directory.
  * Handles ~ expansion and relative path resolution.
+ *
+ * Effect-based callers (session prompt) run with `InstanceRef`, not the
+ * ambient instance context, so they must pass `options.directory` or the
+ * cwd.updated event is silently skipped and the TUI footer goes stale
+ * (LAC-3732).
  */
-export function setCwd(dir: string): void {
+export function setCwd(dir: string, options?: { directory?: string }): void {
   let resolved = dir
 
   // Handle ~ expansion
@@ -66,17 +71,22 @@ export function setCwd(dir: string): void {
   // Publish event if cwd changed. EventV2 / Bus refactor (upstream PR #29068)
   // collapsed BusEvent.publish into GlobalBus.emit for ambient (non-Effect) callers.
   if (changed) {
-    try {
-      const ctx = instanceContext.use()
+    let directory = options?.directory
+    if (directory === undefined) {
+      try {
+        directory = instanceContext.use().directory
+      } catch {
+        // No instance context and no explicit directory; skip publishing
+      }
+    }
+    if (directory !== undefined) {
       GlobalBus.emit("event", {
-        directory: ctx.directory,
+        directory,
         payload: {
           type: CwdEvent.Updated.type,
           properties: { cwd: resolved },
         },
       })
-    } catch {
-      // No instance context available; skip publishing
     }
   }
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -453,7 +453,7 @@ const layer = Layer.effect(
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const markReady = ready ? ready.open.pipe(Effect.asVoid) : Effect.void
-          const { msg, part, cwd } = yield* Effect.gen(function* () {
+          const { msg, part, cwd, directory } = yield* Effect.gen(function* () {
             const ctx = yield* InstanceState.context
             const session = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
             if (session.revert) {
@@ -517,7 +517,7 @@ const layer = Layer.effect(
               },
             }
             yield* sessions.updatePart(part)
-            return { msg, part, cwd: getCwd(ctx.directory) }
+            return { msg, part, cwd: getCwd(ctx.directory), directory: ctx.directory }
           }).pipe(Effect.ensuring(markReady))
 
           const cfg = yield* config.get()
@@ -629,7 +629,7 @@ const layer = Layer.effect(
                 const payload = (newlineIndex !== -1 ? afterSentinel.slice(0, newlineIndex) : afterSentinel).trim()
                 const parsed = parseCwdSentinelPayload(payload)
                 if (parsed.exitCode !== null) commandExitCode = parsed.exitCode
-                if (parsed.cwd) setCwd(parsed.cwd)
+                if (parsed.cwd) setCwd(parsed.cwd, { directory })
                 cleanOutput = stripSentinel(output)
               }
 

--- a/packages/opencode/test/plugin/cwd.test.ts
+++ b/packages/opencode/test/plugin/cwd.test.ts
@@ -164,6 +164,49 @@ describe("parseCwdSentinelPayload — LAC-2693 regression", () => {
   })
 })
 
+// LAC-3732 regression: the session prompt runs under Effect InstanceRef, not
+// the ambient instance context (only CLI bootstrap enters that), so the emit
+// guarded by instanceContext.use() silently never fired and the TUI footer cwd
+// went stale. setCwd must publish when the caller passes the directory.
+describe("CwdEvent.Updated without ambient context — LAC-3732 regression", () => {
+  test("published when caller passes directory explicitly", async () => {
+    const received: string[] = []
+    const unsub = subscribeCwd(received)
+
+    setCwd("/tmp", { directory: "/some/project" })
+    await Bun.sleep(10)
+
+    expect(received).toEqual(["/tmp"])
+    unsub()
+  })
+
+  test("event carries the caller-provided instance directory", async () => {
+    const directories: (string | undefined)[] = []
+    const handler = (event: GlobalEvent) => {
+      if (event.payload?.type !== CwdEvent.Updated.type) return
+      directories.push(event.directory)
+    }
+    GlobalBus.on("event", handler)
+
+    setCwd("/tmp", { directory: "/some/project" })
+    await Bun.sleep(10)
+
+    expect(directories).toEqual(["/some/project"])
+    GlobalBus.off("event", handler)
+  })
+
+  test("not published when no ambient context and no directory passed", async () => {
+    const received: string[] = []
+    const unsub = subscribeCwd(received)
+
+    setCwd("/tmp")
+    await Bun.sleep(10)
+
+    expect(received).toEqual([])
+    unsub()
+  })
+})
+
 // LAC-742 regression: CwdEvent.Updated bus event
 describe("CwdEvent.Updated — LAC-742 regression", () => {
   test("published when cwd changes", async () => {


### PR DESCRIPTION
## Summary

Fixes [LAC-3732](https://paperclip.local/LAC/issues/LAC-3732) — QA defect from LAC-3268: submitting `cd /tmp` in Shell mode did not update the footer `shortenedWorkingDir`.

**Root cause:** `setCwd()` in `packages/opencode/plugin/shell-mode/cwd.ts` only emitted `cwd.updated` when the ambient AsyncLocalStorage instance context was present (`instanceContext.use()`), swallowing the `NotFound` throw in a bare `catch`. But the session prompt (the live shell-mode path) runs under Effect's `InstanceRef` — the ambient context is only entered by CLI `bootstrap()`, as the docstring on `getCwd()` in the same file already warns. So the emit silently never fired: the event chain (GlobalBus → worker RPC `global.event` → TUI sync store → footer) is intact, it just never received the event. This also explains why the QA repro logged nothing.

## Changes

- `setCwd(dir, options?: { directory?: string })` — an explicit directory bypasses the ambient-context lookup; falls back to ambient context as before; still skips emission when neither is available.
- `session/prompt.ts` threads `ctx.directory` (already in scope for the `getCwd` fallbacks) through to the sentinel-parse `setCwd` call.
- Regression tests (`test/plugin/cwd.test.ts`): emit fires without ambient context when directory is passed; event carries the caller's directory; no emit when neither source is available. The two new emit tests fail on the old code.

Not changed: `session-shell.ts:296` also calls `setCwd` without a directory, but `SessionShellExecute` has no production callers today — behavior there is unchanged (works iff ambient context exists, same as before).

## Testing

- `bun test test/plugin/cwd.test.ts` — 23 pass (new tests failed before the fix, TDD).
- `bun test test/plugin/shell-mode.test.ts` — 32 pass.
- `bun run typecheck` (packages/opencode) — clean.
- Manual repro per issue: TUI in tmux, ctrl+space Shell mode, `cd /tmp` → footer updates to `/private/tmp`; `pwd` confirms. Before-fix behavior documented in LAC-3268 QA transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)